### PR TITLE
Adjust references of "params" to "settings" based on recent changes to "noop-discovery"

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -40,7 +40,7 @@ module.exports = (argv) => {
       const interval = setInterval(() => {}, 1000)
       console.log(chalk.green(`Your application dev server is running on https://localnoop.app:${results.devServer.port}`)) 
       if (process.stdin.setRawMode) {
-        console.log(chalk.cyan(`Press [i] to open the inspector or [q] to stop the dev server`))
+        console.log(chalk.cyan(`Press [i] to open the inspector, [o] to open the dev server, or [q] to stop the dev server`))
         readline.emitKeypressEvents(process.stdin)
         process.stdin.setRawMode(true)
         process.stdin.on('keypress', (str, key) => {

--- a/lib/devServer.js
+++ b/lib/devServer.js
@@ -93,7 +93,7 @@ class DevServer {
       }],
       predeployTasks: ['setupRelationships', (results, done) => {
         const containers = this.componentContainers.filter((componentContainer) => {
-          return (componentContainer.component.type === 'task' && componentContainer.component.params.lifecycles.includes('predeploy'))
+          return (componentContainer.component.type === 'task' && componentContainer.component.settings.lifecycles.includes('predeploy'))
         })
         async.eachSeries(containers, (container, done) => {
           console.log(`Starting predeploy task '${container.friendlyName}'`)
@@ -116,7 +116,7 @@ class DevServer {
       }],
       postdeployTasks: ['postdeployDelay', (results, done) => {
         const containers = this.componentContainers.filter((componentContainer) => {
-          return (componentContainer.component.type === 'task' && componentContainer.component.params.lifecycles.includes('postdeploy'))
+          return (componentContainer.component.type === 'task' && componentContainer.component.settings.lifecycles.includes('postdeploy'))
         })
         async.eachSeries(containers, (container, done) => {
           console.log(`Starting postdeploy task '${container.friendlyName}'`)

--- a/lib/resources/dynamodb.js
+++ b/lib/resources/dynamodb.js
@@ -49,11 +49,11 @@ class DynamodbContainer extends ResourceContainer {
           AWS_SECRET_ACCESS_KEY: '1234567890'
         }
       }
-      const attributeDefinitions = [`AttributeName=${this.resource.params.hashKeyName},AttributeType=${this.resource.params.hashKeyType}`]
-      const keySchema = [`AttributeName=${this.resource.params.hashKeyName},KeyType=HASH`]
-      if (this.resource.params.rangeKeyName) {
-        attributeDefinitions.push(`AttributeName=${this.resource.params.rangeKeyName},AttributeType=${this.resource.params.rangeKeyType}`)
-        keySchema.push(`AttributeName=${this.resource.params.rangeKeyName},KeyType=RANGE`)
+      const attributeDefinitions = [`AttributeName=${this.resource.settings.hashKeyName},AttributeType=${this.resource.settings.hashKeyType}`]
+      const keySchema = [`AttributeName=${this.resource.settings.hashKeyName},KeyType=HASH`]
+      if (this.resource.settings.rangeKeyName) {
+        attributeDefinitions.push(`AttributeName=${this.resource.settings.rangeKeyName},AttributeType=${this.resource.settings.rangeKeyType}`)
+        keySchema.push(`AttributeName=${this.resource.settings.rangeKeyName},KeyType=RANGE`)
       }
       setupContainer.cmd = ['dynamodb', 'create-table', '--endpoint-url', `http://${this.name}:8000`, '--region', 'local', '--table-name', this.name, '--attribute-definitions', ...attributeDefinitions, '--key-schema', ...keySchema, '--provisioned-throughput', 'ReadCapacityUnits=5,WriteCapacityUnits=5']
       setupContainer.start(done)

--- a/lib/routerContainer.js
+++ b/lib/routerContainer.js
@@ -40,7 +40,7 @@ class RouterContainer extends Container {
           pattern: route.pattern,
           componentName: route.component.name,
           hostname: `noop-${route.component.app.id}-component-${route.component.name}`,
-          port: route.component.params.port,
+          port: route.component.settings.port,
           internal: route.internal
         }
       }))


### PR DESCRIPTION
`noop-discovery` recently changed to using the key `settings` instead of `params` to access attributes related to resources/components. I've swapped the usage of the key `settings` to `params` as it relates to resources/components I'm currently using with `noop-local`. There are several dozen other usages of the term `params` need to be examined in this repo.