### PR TITLE
fix dbpath for dynamodb

### DIFF
--- a/lib/resources/dynamodb.js
+++ b/lib/resources/dynamodb.js
@@ -5,7 +5,7 @@ const mkdirp = require('mkdirp')
 class DynamodbContainer extends ResourceContainer {
   constructor (resource, devServer) {
     super(resource, devServer)
-    this.cmd = ['-jar', 'DynamoDBLocal.jar', '-dbPath', '/db']
+    this.cmd = ['-jar', 'DynamoDBLocal.jar', '-dbPath', './']
   }
 
   getImage () {


### PR DESCRIPTION
Fix for error encountered in dynamodb resource when running in WSL: `WARNING: [sqlite] cannot open DB[1855]: com.almworks.sqlite4java.SQLiteException: [14] unable to open database file`.  This bug may or may not be specific to WSL.

Closes #38 