### PR TITLE
Removed usage of pushd in the postinstall script, and replaced with npm's --prefix param

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/rearc/noop-local/issues"
   },
   "scripts": {
-    "postinstall": "pushd lib/inspector/console && mkdir -p node_modules && npm install && npm run build && popd"
+    "postinstall": "npm install --prefix lib/inspector/console && npm run build --prefix lib/inspector/console"
   },
   "homepage": "https://github.com/rearc/noop-local#readme",
   "dependencies": {


### PR DESCRIPTION
Per this issue: https://github.com/noop-cloud/noop-local/issues/41

There are certain shells that do not support the `pushd` command. Pretty sure there shouldn't be any issues replacing the usage of `pushd` with npm's `--prefix` param.

I've tested this out by deleting the `dist` and `node_modules` in the `lib/inspector/console` directory, and then re-running the `noop-local`'s `install` and `postinstall` script. `noop-local` appeared to work fine thereafter.