### PR TITLE
Postinstall Fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "url": "https://github.com/rearc/noop-local/issues"
   },
   "scripts": {
-    "postinstall": "npm install --prefix lib/inspector/console && npm run build --prefix lib/inspector/console"
+    "install-console": "(cd lib/inspector/console && mkdir node_modules && npm install && npm run build)",
+    "postinstall": "npm run install-console"
   },
   "homepage": "https://github.com/rearc/noop-local#readme",
   "dependencies": {


### PR DESCRIPTION
Whoops! Adjustments to the postinstall npm script in v1.0.16 only work when you `npm install` directly from the root directory of `noop-local`. Otherwise installing globally results in an endless installation loop. I've tested out the changes in this PR using `npm pack` and `npm install noop-local-1.0.16.tgz -g`, and the install works properly again.