### PR TITLE
Update Dockerfile Base Images

### DIFF
--- a/lib/resources/dynamodb.js
+++ b/lib/resources/dynamodb.js
@@ -42,7 +42,7 @@ class DynamodbContainer extends ResourceContainer {
       const setupContainer = new Container(this.devServer, 'DynamoSetup', 'job')
       setupContainer.outputLogs = false
       setupContainer.daemon = false
-      setupContainer.getImage = () => { return 'mesosphere/aws-cli' }
+      setupContainer.getImage = () => { return 'mesosphere/aws-cli:latest' }
       setupContainer.getEnv = () => {
         return {
           AWS_ACCESS_KEY_ID: 'ABCDEF',

--- a/lib/resources/mysql.js
+++ b/lib/resources/mysql.js
@@ -7,10 +7,10 @@ class MysqlContainer extends ResourceContainer {
   }
 
   getImage () {
-    if (this.resource.params.version) {
-      return 'mysql:latest' // + this.resource.params.version
+    if (this.resource.settings.version) {
+      return `mysql:${this.resource.settings.version}`
     } else {
-      return 'mysql'
+      return 'mysql:latest'
     }
   }
 

--- a/lib/resources/postgresql.js
+++ b/lib/resources/postgresql.js
@@ -7,7 +7,7 @@ class PostgresqlContainer extends ResourceContainer {
   }
 
   getImage () {
-    return 'postgres:latest'
+    return 'postgres:alpine'
   }
 
   getEnv () {

--- a/lib/static/Dockerfile
+++ b/lib/static/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine
+FROM node:12-alpine
 WORKDIR /opt/static
 COPY package.json package.json
 RUN npm install

--- a/router/Dockerfile
+++ b/router/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:12-alpine
 WORKDIR /router
 COPY package.json package.json
 RUN npm install


### PR DESCRIPTION
`lib/resources/dynamodb.js`:
- Added `:latest` tag to `mesosphere/aws-cli` base image. Without the `:latest` tag multiple versions are downloaded.

`lib/resources/mysql.js`:
- Fixed conditional for using a specific version of `mysql`. Added `:latest` tag if no version is specified.

`lib/resources/postgresql.js`:
- Changed `postgres` base image to Alpine version. Tested with several Noop projects, and did not run into any issues after making this change.

`lib/static/Dockerfile`:
- Changed base image to `node:12-alpine`. This should be the same image that was being used before, but I thought it would be worth it to be more specific. 

`router/Dockerfile`:
- The previously used base image, `node:8-alpine`, is no longer a supported Docker base image. Changed to `node:12-alpine`, as there appears to be no consequence in doing so.