### PR TITLE
Proposal for Noop router (local) logging.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -43,7 +43,12 @@ const yargs = require('yargs')
           alias: 'r',
           type: 'array',
           description: 'Name of resource(s) to run'
-        }
+        },
+        'router-logging': {
+          alias: 'l',
+          type: 'boolean',
+          describe: 'Output global router logs'
+        },
       })
   }, (argv) => {
     runCommand(argv)

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -12,6 +12,7 @@ const findRoot = require('./util/findRoot')
 module.exports = (argv) => {
   const port = argv.port
   const autoReload = !argv.disableReload
+  const routerLogging = !!argv.routerLogging
   const verbose = argv.verbose
   let selectedComponents = argv.component
   let selectedResources = argv.resource
@@ -35,7 +36,8 @@ module.exports = (argv) => {
         verbose,
         selectedComponents,
         selectedResources,
-        autoReload
+        autoReload,
+        routerLogging
       }
       done(null, new DevServer(results.app, port, results.envOverrides, opts))
     }],

--- a/lib/devServer.js
+++ b/lib/devServer.js
@@ -33,6 +33,7 @@ class DevServer {
     this.selectedComponents = opts.selectedComponents
     this.selectedResources = opts.selectedResources
     this.autoReload = opts.autoReload
+    this.routerLogging = opts.routerLogging
     this.certificateChain = null
     this.certificateKey = null
     this.crons = []

--- a/lib/routerContainer.js
+++ b/lib/routerContainer.js
@@ -14,7 +14,7 @@ class RouterContainer extends Container {
   constructor (devServer) {
     super(devServer, 'localapp', 'router')
     this.logColor = 'magenta'
-    this.outputLogs = false
+    this.outputLogs = devServer.routerLogging
     this.hostPortMappings.push({
       container: 90,
       host: this.devServer.port + 2


### PR DESCRIPTION
Adding an option to turn on log output from the noop local router. Helps debugging route setup between different components.

Just a proposal -- I was having some trouble figuring out the routing so I ended up turning on the output flag in the RouterContainer class. This is probably not a comprehensive solution, but I think something like this would be helpful.